### PR TITLE
feat: add user profile page with avatar, bio, followers, and repo count

### DIFF
--- a/src/components/UserProfileCard.tsx
+++ b/src/components/UserProfileCard.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Card, Avatar, Typography, Box } from "@mui/material";
+
+interface UserProfile {
+  avatar_url: string;
+  bio: string | null;
+  followers: number;
+  public_repos: number;
+  login: string;
+}
+
+interface UserProfileCardProps {
+  user: UserProfile;
+}
+
+const UserProfileCard: React.FC<UserProfileCardProps> = ({ user }) => {
+  return (
+    <Card sx={{ maxWidth: 400, margin: "auto", mt: 4, p: 2 }}>
+      <Box display="flex" flexDirection="column" alignItems="center" gap={2}>
+        <Avatar
+          src={user.avatar_url}
+          alt={user.login}
+          sx={{ width: 120, height: 120 }}
+        />
+        <Typography variant="h5">{user.login}</Typography>
+        <Typography variant="body1" color="text.secondary" textAlign="center">
+          {user.bio || "No bio available."}
+        </Typography>
+        <Box display="flex" justifyContent="space-around" width="100%" mt={2}>
+          <Box textAlign="center">
+            <Typography variant="subtitle1" fontWeight="bold">
+              {user.followers}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Followers
+            </Typography>
+          </Box>
+          <Box textAlign="center">
+            <Typography variant="subtitle1" fontWeight="bold">
+              {user.public_repos}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Repositories
+            </Typography>
+          </Box>
+        </Box>
+      </Box>
+    </Card>
+  );
+};
+
+export default UserProfileCard;

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -1,14 +1,54 @@
-import { Box, Grid } from "@mui/material";
+import React, { useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { useUserStore } from "../store/userStore";
+import UserProfileCard from "../components/UserProfileCard";
+import { CircularProgress, Typography, Box, Grid } from "@mui/material";
 
-export default function UserProfilePage() {
+const UserProfilePage: React.FC = () => {
+  const { username } = useParams<{ username: string }>();
+  const { userProfile, profileLoading, profileError, fetchUserProfile } =
+    useUserStore();
+
+  useEffect(() => {
+    if (username) {
+      fetchUserProfile(username);
+    }
+  }, [username, fetchUserProfile]);
+
+  if (profileLoading) {
+    return (
+      <Box display="flex" justifyContent="center" mt={4}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (profileError) {
+    return (
+      <Typography color="error" align="center" mt={4}>
+        {profileError}
+      </Typography>
+    );
+  }
+
+  if (!userProfile) {
+    return (
+      <Typography align="center" mt={4}>
+        No user data available.
+      </Typography>
+    );
+  }
+
   return (
     <Grid container spacing={2}>
       <Grid item xs={12} md={4} lg={5}>
-        <Box>Profile</Box>
+        <UserProfileCard user={userProfile} />
       </Grid>
       <Grid item xs={12} md={4} lg={7}>
         <Box>Respository List</Box>
       </Grid>
     </Grid>
   );
-}
+};
+
+export default UserProfilePage;

--- a/src/services/githubAPI.ts
+++ b/src/services/githubAPI.ts
@@ -4,3 +4,8 @@ export async function searchUsers(query: string) {
   const res = await axios.get(`https://api.github.com/search/users?q=${query}`);
   return res.data.items;
 }
+
+export const fetchUserProfileAPI = async (username: string) => {
+  const response = await axios.get(`https://api.github.com/users/${username}`);
+  return response.data;
+};


### PR DESCRIPTION
- Fetched and displayed GitHub user details: avatar, bio, followers, and public repo count.
- Added loading and error states for profile data fetch.